### PR TITLE
Allow using the TrackingPermision from iOS 14.0.0

### DIFF
--- a/Sources/TrackingPermission/TrackingPermission.swift
+++ b/Sources/TrackingPermission/TrackingPermission.swift
@@ -26,7 +26,7 @@ import PermissionsKit
 #if PERMISSIONSKIT_TRACKING
 import AppTrackingTransparency
 
-@available(iOS 14.5, tvOS 14.5, *)
+@available(iOS 14, tvOS 14, *)
 public extension Permission {
 
     static var tracking: TrackingPermission {
@@ -34,7 +34,7 @@ public extension Permission {
     }
 }
 
-@available(iOS 14.5, tvOS 14.5, *)
+@available(iOS 14, tvOS 14, *)
 public class TrackingPermission: Permission {
     
     open override var kind: Permission.Kind { .tracking }


### PR DESCRIPTION
## Goal
- Allow using the `TrackingPermision` with iOS from iOS 14.0.0

## Why? 
-  One of my apps targeted iOS 14. It actually tracks users. 
- And I need to request Tracking permission even on the iOS device below iOS 14.5.  (from 14.0.0 to 14.4) to make the app tracking function works. Otherwise, no data and no cookies for tracking could save on the app and its in-app web view.
- I don't know why `TrackingPermision` required iOS 14.5.
- I created a fork and change it to available from iOS 14.0.0
