### PR TITLE
Fix build warning

### DIFF
--- a/Sources/LocationExtension/LocationAccuracy.swift
+++ b/Sources/LocationExtension/LocationAccuracy.swift
@@ -24,7 +24,7 @@ import MapKit
 
 extension CLLocationManager {
     
-    open func setAccuracy(_ value: LocationAccuracy) {
+    public func setAccuracy(_ value: LocationAccuracy) {
         desiredAccuracy = value.coreLocationAccuracy
     }
 }


### PR DESCRIPTION
Non-'@objc' instance method in extensions cannot be overridden; use 'public' instead

## Goal
<!--- Provide details about reason changes. -->
