### PR TITLE
Add writeOnly type for calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Universal API for request permission and get its statuses. Available `.authorize
 | Icon |  Permission | Key for `Info.plist` | Get Status | Make Request |
 | :--: | :---------- | :------------------- | :--------: | :----------: |
 | <img src="https://cdn.sparrowcode.io/github/permissionskit/icons/bluetooth.png" width="38"> | Bluetooth | NSBluetoothAlwaysUsageDescription, NSBluetoothPeripheralUsageDescription | ✅ | ✅ |
-| <img src="https://cdn.sparrowcode.io/github/permissionskit/icons/calendar.png" width="38"> | Calendar | NSCalendarsUsageDescription | ✅ | ✅ |
+| <img src="https://cdn.sparrowcode.io/github/permissionskit/icons/calendar.png" width="38"> | Calendar | NSCalendarsUsageDescription, NSCalendarsFullAccessUsageDescription, NSCalendarsWriteOnlyAccessUsageDescription | ✅ | ✅ |
 | <img src="https://cdn.sparrowcode.io/github/permissionskit/icons/camera.png" width="38"> | Camera | NSCameraUsageDescription | ✅ | ✅ |
 | <img src="https://cdn.sparrowcode.io/github/permissionskit/icons/contacts.png" width="38"> | Contacts | NSContactsUsageDescription | ✅ | ✅ |
 | <img src="https://cdn.sparrowcode.io/github/permissionskit/icons/faceid.png" width="38"> | FaceID | NSFaceIDUsageDescription | ✅ | ✅ |
@@ -68,7 +68,7 @@ Universal API for request permission and get its statuses. Available `.authorize
 | <img src="https://cdn.sparrowcode.io/github/permissionskit/icons/motion.png" width="38"> | Motion | NSMotionUsageDescription | ✅ | ✅ |
 | <img src="https://cdn.sparrowcode.io/github/permissionskit/icons/notifications.png" width="38"> | Notification | | ✅ | ✅ |
 | <img src="https://cdn.sparrowcode.io/github/permissionskit/icons/photos.png" width="38"> | Photo Library | NSPhotoLibraryUsageDescription, NSPhotoLibraryAddUsageDescription | ✅ | ✅ |
-| <img src="https://cdn.sparrowcode.io/github/permissionskit/icons/reminders.png" width="38"> | Reminders | NSRemindersUsageDescription | ✅ | ✅ |
+| <img src="https://cdn.sparrowcode.io/github/permissionskit/icons/reminders.png" width="38"> | Reminders | NSRemindersUsageDescription, NSRemindersFullAccessUsageDescription | ✅ | ✅ |
 | <img src="https://cdn.sparrowcode.io/github/permissionskit/icons/siri.png" width="38"> | Siri | NSSiriUsageDescription | ✅ | ✅ |
 | <img src="https://cdn.sparrowcode.io/github/permissionskit/icons/speech.png" width="38"> | Speech Recognizer | NSSpeechRecognitionUsageDescription | ✅ | ✅ |
 | <img src="https://cdn.sparrowcode.io/github/permissionskit/icons/tracking.png" width="38"> | Tracking | NSUserTrackingUsageDescription | ✅ | ✅ |

--- a/Sources/CalendarPermission/CalendarPermission.swift
+++ b/Sources/CalendarPermission/CalendarPermission.swift
@@ -32,6 +32,10 @@ public extension Permission {
     static var calendar: CalendarPermission {
         return CalendarPermission(kind: .calendar)
     }
+}
+
+@available(iOS 17.0, *)
+public extension Permission {
     
     static var calendarWriteOnly: CalendarPermission {
         return CalendarPermission(kind: .calendarWriteOnly)

--- a/Sources/PermissionsKit/Data/Text.swift
+++ b/Sources/PermissionsKit/Data/Text.swift
@@ -31,7 +31,8 @@ enum Texts {
             return NSLocalizedString("permission photoLibrary name", bundle: bundle, comment: "")
         case .microphone:
             return NSLocalizedString("permission microphone name", bundle: bundle, comment: "")
-        case .calendar:
+        case .calendar,
+             .calendarWriteOnly:
             return NSLocalizedString("permission calendar name", bundle: bundle, comment: "")
         case .contacts:
             return NSLocalizedString("permission contacts name", bundle: bundle, comment: "")

--- a/Sources/PermissionsKit/Permission.swift
+++ b/Sources/PermissionsKit/Permission.swift
@@ -110,9 +110,10 @@ open class Permission: Equatable {
         case photoLibrary = 1
         case microphone = 3
         case calendar = 4
-        case contacts = 5
-        case reminders = 6
-        case speech = 7
+        case calendarWriteOnly = 5
+        case contacts = 6
+        case reminders = 7
+        case speech = 8
         case locationWhenInUse = 9
         case locationAlways = 10
         case motion = 11
@@ -131,7 +132,8 @@ open class Permission: Equatable {
                 return "Photo Library"
             case .microphone:
                 return "Microphone"
-            case .calendar:
+            case .calendar,
+                 .calendarWriteOnly:
                 return "Calendar"
             case .contacts:
                 return "Contacts"


### PR DESCRIPTION
## Goal
with iOS 17 there are two new methods to request access for calendars.

- `requestWriteOnlyAccessToEvents` -> `.calendarWriteOnly`
- `requestFullAccessToEvents` -> `.calendar`