### PR TITLE
[ADD] new iOS 17 calendar and reminders permission handling including full access and write only authorization

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,6 +32,10 @@ let package = Package(
             targets: ["CalendarPermission"]
         ),
         .library(
+            name: "CalendarWriteOnlyAccessPermission",
+            targets: ["CalendarWriteOnlyAccessPermission"]
+        ),
+        .library(
             name: "ContactsPermission",
             targets: ["ContactsPermission"]
         ),
@@ -134,6 +138,14 @@ let package = Package(
             dependencies: [.target(name: "PermissionsKit")],
             swiftSettings: [
                 .define("PERMISSIONSKIT_CALENDAR"),
+                .define("PERMISSIONSKIT_SPM")
+            ]
+        ),
+        .target(
+            name: "CalendarWriteOnlyAccessPermission",
+            dependencies: [.target(name: "PermissionsKit")],
+            swiftSettings: [
+                .define("PERMISSIONSKIT_CALENDAR_WRITEONLYACCESS"),
                 .define("PERMISSIONSKIT_SPM")
             ]
         ),

--- a/PermissionsKit.podspec
+++ b/PermissionsKit.podspec
@@ -69,6 +69,14 @@ Pod::Spec.new do |s|
     }
   end
 
+  s.subspec 'CalendarWriteOnlyAccessPermission' do |subspec|
+    subspec.dependency 'PermissionsKit/Core'
+    subspec.source_files = "Sources/CalendarWriteOnlyAccessPermission/**/*.swift"
+    subspec.pod_target_xcconfig = {
+        "SWIFT_ACTIVE_COMPILATION_CONDITIONS"  => "PERMISSIONSKIT_CALENDAR PERMISSIONSKIT_COCOAPODS"
+    }
+  end
+
   s.subspec 'ContactsPermission' do |subspec|
     subspec.dependency 'PermissionsKit/Core'
     subspec.source_files = "Sources/ContactsPermission/**/*.swift"

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ Universal API for request permission and get its statuses. Available `.authorize
 | Icon |  Permission | Key for `Info.plist` | Get Status | Make Request |
 | :--: | :---------- | :------------------- | :--------: | :----------: |
 | <img src="https://cdn.sparrowcode.io/github/permissionskit/icons/bluetooth.png" width="38"> | Bluetooth | NSBluetoothAlwaysUsageDescription, NSBluetoothPeripheralUsageDescription | ✅ | ✅ |
-| <img src="https://cdn.sparrowcode.io/github/permissionskit/icons/calendar.png" width="38"> | Calendar | NSCalendarsUsageDescription | ✅ | ✅ |
+| <img src="https://cdn.sparrowcode.io/github/permissionskit/icons/calendar.png" width="38"> | Calendar | NSCalendarsUsageDescription, NSCalendarsFullAccessUsageDescription (iOS 17) | ✅ | ✅ |
+| <img src="https://cdn.sparrowcode.io/github/permissionskit/icons/calendar.png" width="38"> | Calendar Write Only Access | NSCalendarsWriteOnlyAccessUsageDescription (iOS 17) | ✅ | ✅ |
 | <img src="https://cdn.sparrowcode.io/github/permissionskit/icons/camera.png" width="38"> | Camera | NSCameraUsageDescription | ✅ | ✅ |
 | <img src="https://cdn.sparrowcode.io/github/permissionskit/icons/contacts.png" width="38"> | Contacts | NSContactsUsageDescription | ✅ | ✅ |
 | <img src="https://cdn.sparrowcode.io/github/permissionskit/icons/faceid.png" width="38"> | FaceID | NSFaceIDUsageDescription | ✅ | ✅ |
@@ -65,7 +66,7 @@ Universal API for request permission and get its statuses. Available `.authorize
 | <img src="https://cdn.sparrowcode.io/github/permissionskit/icons/motion.png" width="38"> | Motion | NSMotionUsageDescription | ✅ | ✅ |
 | <img src="https://cdn.sparrowcode.io/github/permissionskit/icons/notifications.png" width="38"> | Notification | | ✅ | ✅ |
 | <img src="https://cdn.sparrowcode.io/github/permissionskit/icons/photos.png" width="38"> | Photo Library | NSPhotoLibraryUsageDescription, NSPhotoLibraryAddUsageDescription | ✅ | ✅ |
-| <img src="https://cdn.sparrowcode.io/github/permissionskit/icons/reminders.png" width="38"> | Reminders | NSRemindersUsageDescription | ✅ | ✅ |
+| <img src="https://cdn.sparrowcode.io/github/permissionskit/icons/reminders.png" width="38"> | Reminders | NSRemindersUsageDescription, NSRemindersFullAccessUsageDescription (iOS 17) | ✅ | ✅ |
 | <img src="https://cdn.sparrowcode.io/github/permissionskit/icons/siri.png" width="38"> | Siri | NSSiriUsageDescription | ✅ | ✅ |
 | <img src="https://cdn.sparrowcode.io/github/permissionskit/icons/speech.png" width="38"> | Speech Recognizer | NSSpeechRecognitionUsageDescription | ✅ | ✅ |
 | <img src="https://cdn.sparrowcode.io/github/permissionskit/icons/tracking.png" width="38"> | Tracking | NSUserTrackingUsageDescription | ✅ | ✅ |
@@ -111,6 +112,7 @@ Due to Apple's new policy regarding permission access you need to specifically d
 pod 'PermissionsKit/CameraPermission', :git => 'https://github.com/sparrowcode/PermissionsKit'
 pod 'PermissionsKit/ContactsPermission', :git => 'https://github.com/sparrowcode/PermissionsKit'
 pod 'PermissionsKit/CalendarPermission', :git => 'https://github.com/sparrowcode/PermissionsKit'
+pod 'PermissionsKit/CalendarWriteOnlyAccessPermission', :git => 'https://github.com/sparrowcode/PermissionsKit'
 pod 'PermissionsKit/PhotoLibraryPermission', :git => 'https://github.com/sparrowcode/PermissionsKit'
 pod 'PermissionsKit/NotificationPermission', :git => 'https://github.com/sparrowcode/PermissionsKit'
 pod 'PermissionsKit/MicrophonePermission', :git => 'https://github.com/sparrowcode/PermissionsKit'

--- a/Sources/CalendarPermission/CalendarPermission.swift
+++ b/Sources/CalendarPermission/CalendarPermission.swift
@@ -37,9 +37,13 @@ public extension Permission {
 public class CalendarPermission: Permission {
     
     open override var kind: Permission.Kind { .calendar }
-    open var usageDescriptionKey: String? { "NSCalendarsUsageDescription" }
-    open var usageFullAccessDescriptionKey: String? { "NSCalendarsFullAccessUsageDescription" }
-    open var usageWriteOnlyAccessDescriptionKey: String? { "NSCalendarsWriteOnlyAccessUsageDescription" }
+    open var usageDescriptionKey: String? {
+        if #available(iOS 17.0, *) {
+            return "NSCalendarsFullAccessUsageDescription"
+        } else {
+            return "NSCalendarsUsageDescription"
+        }
+    }
     
     public override var status: Permission.Status {
         switch EKEventStore.authorizationStatus(for: EKEntityType.event) {
@@ -48,7 +52,7 @@ public class CalendarPermission: Permission {
         case .fullAccess: return .authorized
         case .notDetermined: return .notDetermined
         case .restricted: return .denied
-        case .writeOnly: return .authorized
+        case .writeOnly: return .denied
         @unknown default: return .denied
         }
     }

--- a/Sources/PermissionsKit/Data/Text.swift
+++ b/Sources/PermissionsKit/Data/Text.swift
@@ -33,6 +33,8 @@ enum Texts {
             return NSLocalizedString("permission microphone name", bundle: bundle, comment: "")
         case .calendar:
             return NSLocalizedString("permission calendar name", bundle: bundle, comment: "")
+        case .calendarWriteOnlyAccess:
+            return NSLocalizedString("permission calendar write only access name", bundle: bundle, comment: "")
         case .contacts:
             return NSLocalizedString("permission contacts name", bundle: bundle, comment: "")
         case .reminders:

--- a/Sources/PermissionsKit/Permission.swift
+++ b/Sources/PermissionsKit/Permission.swift
@@ -110,9 +110,10 @@ open class Permission: Equatable {
         case photoLibrary = 1
         case microphone = 3
         case calendar = 4
-        case contacts = 5
-        case reminders = 6
-        case speech = 7
+        case calendarWriteOnlyAccess = 5
+        case contacts = 6
+        case reminders = 7
+        case speech = 8
         case locationWhenInUse = 9
         case locationAlways = 10
         case motion = 11
@@ -133,6 +134,8 @@ open class Permission: Equatable {
                 return "Microphone"
             case .calendar:
                 return "Calendar"
+            case .calendarWriteOnlyAccess:
+                return "Calendar Write Only Access"
             case .contacts:
                 return "Contacts"
             case .reminders:

--- a/Sources/PermissionsKit/Resources/Localization/ar.lproj/Localizable.strings
+++ b/Sources/PermissionsKit/Resources/Localization/ar.lproj/Localizable.strings
@@ -4,6 +4,8 @@
 
 "permission microphone name" = "المايكروفون";
 
+"permission calendar write only access name" = "التقويم الكتابة الوصول فقط";
+
 "permission calendar name" = "التقويم";
 
 "permission contacts name" = "جهات الاتصال";

--- a/Sources/PermissionsKit/Resources/Localization/de.lproj/Localizable.strings
+++ b/Sources/PermissionsKit/Resources/Localization/de.lproj/Localizable.strings
@@ -19,6 +19,8 @@
 
 "permission microphone name" = "Mikrofon";
 
+"permission calendar write only access name" = "Nur Schreibzugriff auf den Kalender";
+
 "permission calendar name" = "Kalender";
 
 "permission contacts name" = "Kontakte";

--- a/Sources/PermissionsKit/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/PermissionsKit/Resources/Localization/en.lproj/Localizable.strings
@@ -4,6 +4,8 @@
 
 "permission microphone name" = "Microphone";
 
+"permission calendar write only access name" = "Calendar write only access";
+
 "permission calendar name" = "Calendar";
 
 "permission contacts name" = "Contacts";

--- a/Sources/PermissionsKit/Resources/Localization/es.lproj/Localizable.strings
+++ b/Sources/PermissionsKit/Resources/Localization/es.lproj/Localizable.strings
@@ -4,6 +4,8 @@
 
 "permission microphone name" = "Micrófono";
 
+"permission calendar write only access name" = "Calendario acceso solo escritura";
+
 "permission calendar name" = "Calendario";
 
 "permission contacts name" = "Contactos";

--- a/Sources/PermissionsKit/Resources/Localization/fa.lproj/Localizable.strings
+++ b/Sources/PermissionsKit/Resources/Localization/fa.lproj/Localizable.strings
@@ -4,6 +4,8 @@
 
 "permission microphone name" = "میکروفون";
 
+"permission calendar write only access name" = "دسترسی فقط نوشتن تقویم";
+
 "permission calendar name" = "تقویم";
 
 "permission contacts name" = "مخاطبین";

--- a/Sources/PermissionsKit/Resources/Localization/fr.lproj/Localizable.strings
+++ b/Sources/PermissionsKit/Resources/Localization/fr.lproj/Localizable.strings
@@ -4,6 +4,8 @@
 
 "permission microphone name" = "Microphone";
 
+"permission calendar write only access name" = "Accès en écriture seule au calendrier";
+
 "permission calendar name" = "Calendrier";
 
 "permission contacts name" = "Contacts";

--- a/Sources/PermissionsKit/Resources/Localization/it.lproj/Localizable.strings
+++ b/Sources/PermissionsKit/Resources/Localization/it.lproj/Localizable.strings
@@ -4,6 +4,8 @@
 
 "permission microphone name" = "Microphone";
 
+"permission calendar write only access name" = "Accesso in sola scrittura al calendario";
+
 "permission calendar name" = "Calendar";
 
 "permission contacts name" = "Contacts";

--- a/Sources/PermissionsKit/Resources/Localization/nl.lproj/Localizable.strings
+++ b/Sources/PermissionsKit/Resources/Localization/nl.lproj/Localizable.strings
@@ -4,6 +4,8 @@
 
 "permission microphone name" = "Microfoon";
 
+"permission calendar write only access name" = "Agenda alleen schrijftoegang";
+
 "permission calendar name" = "Kalender";
 
 "permission contacts name" = "Contacten";

--- a/Sources/PermissionsKit/Resources/Localization/pl.lproj/Localizable.strings
+++ b/Sources/PermissionsKit/Resources/Localization/pl.lproj/Localizable.strings
@@ -4,6 +4,8 @@
 
 "permission microphone name" = "Mikrofon";
 
+"permission calendar write only access name" = "Dostęp tylko do zapisu w kalendarzu";
+
 "permission calendar name" = "Kalendarz";
 
 "permission contacts name" = "Kontakty";

--- a/Sources/PermissionsKit/Resources/Localization/pt.lproj/Localizable.strings
+++ b/Sources/PermissionsKit/Resources/Localization/pt.lproj/Localizable.strings
@@ -4,6 +4,8 @@
 
 "permission microphone name" = "Microfone";
 
+"permission calendar write only access name" = "Acesso somente gravação ao calendário";
+
 "permission calendar name" = "Calendário";
 
 "permission contacts name" = "Contactos";

--- a/Sources/PermissionsKit/Resources/Localization/ru.lproj/Localizable.strings
+++ b/Sources/PermissionsKit/Resources/Localization/ru.lproj/Localizable.strings
@@ -4,6 +4,8 @@
 
 "permission microphone name" = "Микрофон";
 
+"permission calendar write only access name" = "доступ к календарю только для записи";
+
 "permission calendar name" = "Календарь";
 
 "permission contacts name" = "Контакты";

--- a/Sources/PermissionsKit/Resources/Localization/uk.lproj/Localizable.strings
+++ b/Sources/PermissionsKit/Resources/Localization/uk.lproj/Localizable.strings
@@ -4,6 +4,8 @@
 
 "permission microphone name" = "Мікрофон";
 
+"permission calendar write only access name" = "доступ лише для запису в календарі";
+
 "permission calendar name" = "Календар";
 
 "permission contacts name" = "Контакти";

--- a/Sources/PermissionsKit/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/Sources/PermissionsKit/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -4,6 +4,8 @@
 
 "permission microphone name" = "麥克風";
 
+"permission calendar write only access name" = "日曆只寫訪問";
+
 "permission calendar name" = "日曆";
 
 "permission contacts name" = "通訊錄";

--- a/Sources/PermissionsKit/Resources/Localization/zh_Hans.lproj/Localizable.strings
+++ b/Sources/PermissionsKit/Resources/Localization/zh_Hans.lproj/Localizable.strings
@@ -4,6 +4,8 @@
 
 "permission microphone name" = "麦克风";
 
+"permission calendar write only access name" = "日历只写访问";
+
 "permission calendar name" = "日历";
 
 "permission contacts name" = "通讯录";


### PR DESCRIPTION
## Goal
Referring to [Issue-318](https://github.com/sparrowcode/PermissionsKit/issues/318) and [PR-319](https://github.com/sparrowcode/PermissionsKit/pull/319): here is the solution to handle the new access levels for calendar and reminders under iOS 17 based on the existing code structure. This PR also takes into account the availability of iOS 17.
I have updated the documentation too.