### PR TITLE
Fix full access request to Calendar

### DIFF
--- a/Sources/CalendarPermission/CalendarPermission.swift
+++ b/Sources/CalendarPermission/CalendarPermission.swift
@@ -105,7 +105,7 @@ public class CalendarPermission: Permission {
             }
             
             let requestFull = {
-                eventStore.requestWriteOnlyAccessToEvents { (accessGranted: Bool, error: Error?) in
+                eventStore.requestFullAccessToEvents { (accessGranted: Bool, error: Error?) in
                     DispatchQueue.main.async {
                         completion()
                     }


### PR DESCRIPTION
There was calling `requestWriteOnlyAccessToEvents` by mistake for Calendar Full Access Request.