### PR TITLE
Adapt ContactsPermission to iOS 18

### DIFF
--- a/Sources/ContactsPermission/ContactsPermission.swift
+++ b/Sources/ContactsPermission/ContactsPermission.swift
@@ -40,7 +40,11 @@ public class ContactsPermission: Permission {
     open var usageDescriptionKey: String? { "NSContactsUsageDescription" }
     
     public override var status: Permission.Status {
-        switch CNContactStore.authorizationStatus(for: .contacts) {
+        let authorizationStatus = CNContactStore.authorizationStatus(for: .contacts)
+        if #available(iOS 18.0, *), authorizationStatus == .limited {
+            return .authorized
+        }
+        switch authorizationStatus {
         case .authorized: return .authorized
         case .denied: return .denied
         case .notDetermined: return .notDetermined


### PR DESCRIPTION
After iOS 18, a new status limited was added to CNAuthorizationStatus - ‘This application is authorized to access some contact data.’ In the limited status, I tried using CNContactStore to fetch contact data, and it successfully retrieved the corresponding data selected by the user. Therefore, I believe this status should be treated as authorized.
